### PR TITLE
Replace polling-based sleep with ConditionVariable

### DIFF
--- a/speedshop-cloudwatch.gemspec
+++ b/speedshop-cloudwatch.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |spec|
         f.start_with?(*%w[bin/ Gemfile .gitignore .github/ .standard.yml])
     end
   end
-  spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "aws-sdk-cloudwatch", ">= 1.81.0"


### PR DESCRIPTION
## Summary
- Replaced clunky polling loop in `Reporter#run_loop` with `ConditionVariable` pattern
- Thread now sleeps for full `config.interval` but wakes immediately when signaled
- Eliminates magic `0.1` constant and simplifies the code
- Cleaned up unused `bindir` and `executables` from gemspec

## Test plan
- [x] All tests pass (`bundle exec rake`)
- [x] Reporter starts and stops correctly
- [x] Thread wakes immediately on `stop!` instead of polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)