### PR TITLE
Optimize drain_queue with swap instead of dup

### DIFF
--- a/lib/speedshop/cloudwatch/reporter.rb
+++ b/lib/speedshop/cloudwatch/reporter.rb
@@ -151,7 +151,13 @@ module Speedshop
       end
 
       def drain_queue
-        @mutex.synchronize { @queue.empty? ? nil : @queue.dup.tap { @queue.clear } }
+        buf = nil
+        @mutex.synchronize do
+          return nil if @queue.empty?
+          buf = @queue
+          @queue = []
+        end
+        buf
       end
 
       def process_namespace(namespace, ns_metrics, high_resolution)


### PR DESCRIPTION
## Summary
- Replaced `@queue.dup.tap { @queue.clear }` with reference swap pattern
- Makes critical section O(1) instead of O(n)
- Avoids copying entire queue when draining metrics
- More efficient under lock contention

## Test plan
- [x] All tests pass (`bundle exec rake`)
- [x] Queue draining works correctly
- [x] No observable behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)