### PR TITLE
Add queue overflow protection with configurable max size

### DIFF
--- a/lib/speedshop/cloudwatch/config.rb
+++ b/lib/speedshop/cloudwatch/config.rb
@@ -8,8 +8,8 @@ module Speedshop
     class Config
       include Singleton
 
-      attr_accessor :interval, :metrics, :namespaces, :logger, :sidekiq_queues, :dimensions, :units, :collectors,
-        :enabled_environments, :environment
+      attr_accessor :interval, :metrics, :namespaces, :logger, :queue_max_size, :sidekiq_queues, :dimensions, :units,
+        :collectors, :enabled_environments, :environment
       attr_writer :client
 
       def initialize
@@ -22,6 +22,7 @@ module Speedshop
 
       def reset
         @interval = 60
+        @queue_max_size = 1000
         @client = nil
         @metrics = {
           puma: [],


### PR DESCRIPTION
## Summary

Implements safeguards to prevent unbounded queue growth in the metric reporter:

- Fixed-size queue with configurable `queue_max_size` (default: 1000)
- Drops oldest metrics when queue reaches capacity (FIFO)
- Clears queue on fork detection to prevent inherited metrics from parent process
- Throttled overflow logging - aggregates drops per flush cycle instead of logging per metric
- Gracefully handles failures by dropping metrics instead of retrying or implementing DLQ

## Mitigated Scenarios

- **Flush failures with continued reporting** - Queue won't grow unbounded
- **High metric volume vs. slow flush rate** - Fixed size backstop prevents memory issues  
- **Fork without proper reinitialization** - Queue cleared on fork detection
- **AWS throttling** - Queue size limited, gracefully drops overflow

## Test Plan

- [x] Queue respects max size limit
- [x] Oldest metrics are dropped on overflow
- [x] Queue is cleared when fork is detected
- [x] Overflow logging is throttled and aggregated
- [x] Overflow counter resets after logging
- [x] All existing tests pass
- [x] Linting passes (flog, flay, standard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)