### PR TITLE
Ignore all rake tasks from reporting

### DIFF
--- a/lib/speedshop/cloudwatch/railtie.rb
+++ b/lib/speedshop/cloudwatch/railtie.rb
@@ -11,8 +11,8 @@ module Speedshop
 
       def self.in_rake_task?
         return false unless defined?(::Rake) && ::Rake.respond_to?(:application)
-        tasks = ::Rake.application.top_level_tasks || []
-        tasks.any? { |t| t.match?(/^(assets:|db:|webpacker:)/) }
+        tasks = ::Rake.application&.top_level_tasks
+        tasks&.any? || false
       end
     end
   end


### PR DESCRIPTION
Broaden rake task detection so any rake invocation skips Cloudwatch reporting middleware insertion.